### PR TITLE
fix: Update Jest to v30 to resolve deprecated module warnings

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -18,16 +18,16 @@
     "react-dom": "19.2.0"
   },
   "devDependencies": {
-    "@jest/globals": "^29.7.0",
+    "@jest/globals": "^30.0.0",
     "@tailwindcss/postcss": "^4",
-    "@types/jest": "^29.5.12",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.0.3",
-    "jest": "^29.7.0",
-    "jest-environment-node": "^29.7.0",
+    "jest": "^30.0.0",
+    "jest-environment-node": "^30.0.0",
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",
     "typescript": "^5"


### PR DESCRIPTION
This PR fixes issue #4 by updating Jest and related packages from v29 to v30.

### Problem
Vercel builds were showing deprecation warnings for:
- `inflight@1.0.6`
- `glob@7.2.3`

These were transitive dependencies of Jest 29.

### Solution
Updated Jest to v30 which uses modern dependencies without these deprecated packages.

### Changes
- Updated `jest` from ^29.7.0 to ^30.0.0
- Updated `@jest/globals` from ^29.7.0 to ^30.0.0
- Updated `@types/jest` from ^29.5.12 to ^30.0.0
- Updated `jest-environment-node` from ^29.7.0 to ^30.0.0

Fixes #4

Generated with [Claude Code](https://claude.ai/code)