### PR TITLE
Fix: Use absolute URLs for Twitter card OG images

### DIFF
--- a/website/app/[name]/page.tsx
+++ b/website/app/[name]/page.tsx
@@ -22,6 +22,8 @@ export async function generateMetadata({
   const found = person.found_in_documents;
   const vanityUrl = `${person.slug}.inepsteinfiles.com`;
   const canonicalUrl = `https://inepsteinfiles.com/${person.slug}?utm_source=x_share`;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://inepsteinfiles.com';
+  const ogImageUrl = `${siteUrl}/api/og/${person.slug}`;
 
   const title = `${person.display_name} ${found ? 'IS' : 'IS NOT'} in the Epstein Files`;
   const description = `${person.total_matches} result${person.total_matches !== 1 ? 's' : ''} found. Sources: ${vanityUrl}`;
@@ -40,7 +42,7 @@ export async function generateMetadata({
       siteName: 'InEpsteinFiles.com',
       images: [
         {
-          url: `/api/og/${person.slug}`,
+          url: ogImageUrl,
           width: 1200,
           height: 628,
           alt: altText,
@@ -52,7 +54,7 @@ export async function generateMetadata({
       card: 'summary_large_image',
       title,
       description,
-      images: [`/api/og/${person.slug}`],
+      images: [ogImageUrl],
     },
   };
 }

--- a/website/app/api/og/index/route.tsx
+++ b/website/app/api/og/index/route.tsx
@@ -1,0 +1,65 @@
+import { ImageResponse } from 'next/og';
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'white',
+          padding: '80px',
+        }}
+      >
+        {/* Question */}
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 72,
+            fontWeight: 900,
+            textAlign: 'center',
+            color: '#000000',
+            lineHeight: 1.2,
+            marginBottom: 60,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          IS [NAME] IN THE<br />EPSTEIN FILES?
+        </div>
+
+        {/* Tagline */}
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 32,
+            color: '#666666',
+            textAlign: 'center',
+            marginBottom: 40,
+          }}
+        >
+          Search official documents
+        </div>
+
+        {/* Proof link */}
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 20,
+            color: '#999999',
+            textAlign: 'center',
+          }}
+        >
+          Proof: inepsteinfiles.com
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 628,
+    }
+  );
+}

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -8,10 +8,33 @@ const publicSans = Public_Sans({
   weight: ["400", "600", "700", "900"],
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://inepsteinfiles.com';
+
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://inepsteinfiles.com'),
+  metadataBase: new URL(siteUrl),
   title: "InEpsteinFiles.com - Search Official Epstein Documents",
   description: "Search publicly released Epstein documents from official U.S. government sources",
+  openGraph: {
+    title: "InEpsteinFiles.com - Search Official Epstein Documents",
+    description: "Search publicly released Epstein documents from official U.S. government sources",
+    url: siteUrl,
+    siteName: 'InEpsteinFiles.com',
+    images: [
+      {
+        url: `${siteUrl}/api/og/index`,
+        width: 1200,
+        height: 628,
+        alt: 'Search Epstein files by name. Neutral public records search.',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: "InEpsteinFiles.com - Search Official Epstein Documents",
+    description: "Search publicly released Epstein documents from official U.S. government sources",
+    images: [`${siteUrl}/api/og/index`],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Fixes #7

This PR fixes the Twitter card preview issue by converting relative OG image URLs to absolute URLs.

## Changes
- Changed OG image URLs from relative to absolute in `[name]/page.tsx`
- Added Twitter card metadata with absolute OG image URL in `layout.tsx`
- Created homepage OG image endpoint at `/api/og/index`

## Testing
After deploying, test by sharing a link on Twitter and verify the preview card appears.

Generated with [Claude Code](https://claude.ai/code)