### PR TITLE
Fix: Add npm overrides to eliminate deprecated dependency warnings

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -31,5 +31,9 @@
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",
     "typescript": "^5"
+  },
+  "overrides": {
+    "glob": "^10.0.0",
+    "inflight": "npm:@aashutoshrathi/safe-inflight@^1.0.1"
   }
 }


### PR DESCRIPTION
This PR fixes issue #4 by adding npm overrides to force modern, non-deprecated versions of transitive dependencies.

### Problem
Vercel builds were showing persistent deprecation warnings for:
- `inflight@1.0.6`
- `glob@7.2.3`

These were transitive dependencies from:
`babel-plugin-istanbul` → `test-exclude@^6.0.0` → `glob@7.2.3` → `inflight@1.0.6`

### Solution
Added npm `overrides` to force newer versions:
- `glob`: Upgraded to `^10.0.0` (latest stable)
- `inflight`: Replaced with `@aashutoshrathi/safe-inflight@^1.0.1` (drop-in replacement)

These overrides will be applied during `npm install` on Vercel, eliminating the deprecation warnings.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)