### PR TITLE
Fix: Include full URL in Twitter share to enable card preview

### DIFF
--- a/website/app/[name]/page.tsx
+++ b/website/app/[name]/page.tsx
@@ -83,7 +83,8 @@ export default async function NamePage({
 
   const found = person.found_in_documents;
   const vanityUrl = `${person.slug}.inepsteinfiles.com`;
-  const shareText = `${person.display_name} ${found ? 'IS' : 'IS NOT'} in the Epstein files. Thoughts? Sources: ${vanityUrl}`;
+  const canonicalUrl = `https://inepsteinfiles.com/${person.slug}`;
+  const shareText = `${person.display_name} ${found ? 'IS' : 'IS NOT'} in the Epstein files. Thoughts?\n\n${canonicalUrl}`;
   const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`;
 
   return (


### PR DESCRIPTION
Fixes #7

## Problem
Twitter cards weren't showing when users clicked "Post on X" because the tweet text didn't include a proper URL with https://. Twitter's card crawler requires a full URL to fetch the metadata.

## Solution
Updated the Twitter share text to include the full canonical URL (`https://inepsteinfiles.com/${slug}`) instead of just the vanity domain name.

## Changes
- Added `canonicalUrl` variable with full https:// URL
- Updated `shareText` to include canonical URL on a new line
- Twitter will now recognize the URL and fetch the card metadata

## Testing
After deploying:
1. Go to https://inepsteinfiles.com/bill-clinton
2. Click "Post on X" button
3. Verify the tweet draft includes the full URL
4. Post the tweet
5. Verify the Twitter card appears with the dynamic image

Generated with [Claude Code](https://claude.ai/code)) | [Branch: `claude/issue-7-20251120-0055`](https://github.com/jessicatmt/inepsteinfiles/tree/claude/issue-7-20251120-0055