### PR TITLE
Fix: Enable dynamic params to show NO page for names not in index

### DIFF
--- a/website/app/[name]/page.tsx
+++ b/website/app/[name]/page.tsx
@@ -4,6 +4,9 @@ import { Person } from '@/types';
 import SearchForm from '../components/SearchForm';
 import { getPersonData } from '@/lib/data';
 
+// Allow dynamic params to handle names not in the index
+export const dynamicParams = true;
+
 export async function generateMetadata({
   params,
 }: {


### PR DESCRIPTION
## Summary
- Add `export const dynamicParams = true` to [name]/page.tsx
- Allows Next.js to handle unknown routes at runtime instead of returning 404
- Names not in the index will now show proper NO page with 0 results

Resolves #9

🤖 Generated with [Claude Code](https://claude.ai/code)