### PR TITLE
feat: Add Most Searched feature with Supabase tracking (#36)

### DIFF
--- a/database/001_create_searches_table.sql
+++ b/database/001_create_searches_table.sql
@@ -1,0 +1,47 @@
+-- Create searches table to track search queries
+-- Run this in the Supabase SQL Editor: https://supabase.com/dashboard/project/etsgwyifhsasexistnpy/editor
+
+CREATE TABLE IF NOT EXISTS searches (
+  id BIGSERIAL PRIMARY KEY,
+  slug TEXT NOT NULL,
+  display_name TEXT,
+  searched_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create index on slug for faster lookups
+CREATE INDEX IF NOT EXISTS idx_searches_slug ON searches(slug);
+
+-- Create index on searched_at for trending queries
+CREATE INDEX IF NOT EXISTS idx_searches_searched_at ON searches(searched_at DESC);
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE searches ENABLE ROW LEVEL SECURITY;
+
+-- Create policy to allow public inserts (tracking searches)
+CREATE POLICY "Allow public inserts" ON searches
+  FOR INSERT
+  TO anon
+  WITH CHECK (true);
+
+-- Create policy to allow public reads (viewing trending)
+CREATE POLICY "Allow public reads" ON searches
+  FOR SELECT
+  TO anon
+  USING (true);
+
+-- Create a view for trending searches (most searched in last 7 days)
+CREATE OR REPLACE VIEW trending_searches AS
+SELECT
+  slug,
+  display_name,
+  COUNT(*) as search_count,
+  MAX(searched_at) as last_searched
+FROM searches
+WHERE searched_at > NOW() - INTERVAL '7 days'
+GROUP BY slug, display_name
+ORDER BY search_count DESC
+LIMIT 10;
+
+-- Grant access to the view
+GRANT SELECT ON trending_searches TO anon;

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,86 @@
+# Database Setup for Most Searched Feature
+
+This directory contains SQL migrations for the InEpsteinFiles.com database.
+
+## Prerequisites
+
+- Supabase account with project created
+- Environment variables configured in Vercel (already done per milestones/)
+
+## Setup Instructions
+
+### 1. Run the SQL Migration
+
+1. Go to your Supabase SQL Editor:
+   https://supabase.com/dashboard/project/etsgwyifhsasexistnpy/editor
+
+2. Copy the contents of `001_create_searches_table.sql`
+
+3. Paste and run the SQL in the editor
+
+4. Verify the table was created:
+   ```sql
+   SELECT * FROM searches LIMIT 1;
+   SELECT * FROM trending_searches;
+   ```
+
+### 2. Verify Environment Variables
+
+These should already be set in Vercel (configured in Dec 2024):
+
+```
+NEXT_PUBLIC_SUPABASE_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+```
+
+If running locally, create a `.env.local` file in the `website/` directory:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
+```
+
+### 3. Test the Feature
+
+1. Deploy or run locally:
+   ```bash
+   cd website
+   npm run dev
+   ```
+
+2. Search for a name on the site
+
+3. Check that the search was tracked:
+   ```sql
+   SELECT * FROM searches ORDER BY created_at DESC LIMIT 10;
+   ```
+
+4. View trending searches:
+   ```sql
+   SELECT * FROM trending_searches;
+   ```
+
+## Schema Overview
+
+### `searches` table
+- Tracks individual search queries
+- Fields: `id`, `slug`, `display_name`, `searched_at`, `created_at`
+- Indexed on `slug` and `searched_at` for performance
+
+### `trending_searches` view
+- Materialized view showing most searched names in last 7 days
+- Auto-calculates search counts
+- Limited to top 10 results
+
+## API Endpoints
+
+- `POST /api/track-search` - Track a search (called automatically)
+- `GET /api/trending` - Get trending searches (cached 5 min)
+
+## Features
+
+- ✅ Automatic search tracking on result pages
+- ✅ "Most Searched" section on homepage
+- ✅ Real-time updates (with 5min cache)
+- ✅ Graceful degradation (tracking failures don't affect UX)
+- ✅ Row Level Security enabled for data protection

--- a/website/app/[name]/page.tsx
+++ b/website/app/[name]/page.tsx
@@ -8,6 +8,7 @@ import CheckItOutPopup from '../components/CheckItOutPopup';
 import ShareButton from '../components/ShareButton';
 import ScreenshotButton from '../components/ScreenshotButton';
 import RandomYesLink from '../components/RandomYesLink';
+import SearchTracker from '../components/SearchTracker';
 import { getPersonData, findAllMatches, getYesPeople } from '@/lib/data';
 import { Person } from '@/types';
 import { rankDocuments, getClassificationIcon } from '@/lib/documentRanking';
@@ -181,6 +182,7 @@ export default async function NamePage({
 
     return (
       <main className="min-h-screen bg-white text-black p-4">
+        <SearchTracker slug={name} displayName={displayName} />
         <div className="max-w-4xl mx-auto">
           {/* Answer Section */}
           <div className="text-center mb-16">
@@ -275,6 +277,7 @@ export default async function NamePage({
 
   return (
     <main className="min-h-screen bg-white text-black p-4">
+      <SearchTracker slug={person.slug} displayName={person.display_name} />
       <div className="max-w-4xl mx-auto">
         {/* Answer Section */}
         <div className="text-center mb-16">

--- a/website/app/api/track-search/route.ts
+++ b/website/app/api/track-search/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { slug, display_name } = body;
+
+    if (!slug || typeof slug !== 'string') {
+      return NextResponse.json(
+        { error: 'Invalid slug parameter' },
+        { status: 400 }
+      );
+    }
+
+    // Track the search in Supabase
+    const supabase = getSupabaseClient();
+    const { error } = await supabase
+      .from('searches')
+      .insert([
+        {
+          slug: slug.toLowerCase(),
+          display_name: display_name || slug,
+        }
+      ]);
+
+    if (error) {
+      console.error('Failed to track search:', error);
+      // Don't fail the request if tracking fails - graceful degradation
+      return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Track search error:', error);
+    // Graceful degradation - don't fail the request
+    return NextResponse.json({ success: true });
+  }
+}
+
+// Only allow POST
+export async function GET() {
+  return NextResponse.json(
+    { error: 'Method not allowed' },
+    { status: 405 }
+  );
+}

--- a/website/app/api/trending/route.ts
+++ b/website/app/api/trending/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseClient } from '@/lib/supabase';
+
+export const revalidate = 300; // Cache for 5 minutes
+
+export async function GET() {
+  try {
+    const supabase = getSupabaseClient();
+
+    // Query the trending_searches view
+    const { data, error } = await supabase
+      .from('trending_searches')
+      .select('*')
+      .limit(10);
+
+    if (error) {
+      console.error('Failed to fetch trending searches:', error);
+      return NextResponse.json({ trending: [] });
+    }
+
+    // Format the data
+    const trending = (data || []).map(item => ({
+      slug: item.slug,
+      display_name: item.display_name,
+      search_count: item.search_count,
+    }));
+
+    return NextResponse.json({ trending });
+  } catch (error) {
+    console.error('Trending API error:', error);
+    return NextResponse.json({ trending: [] });
+  }
+}

--- a/website/app/components/MostSearched.tsx
+++ b/website/app/components/MostSearched.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface TrendingSearch {
+  slug: string;
+  display_name: string;
+  search_count: number;
+}
+
+export default function MostSearched() {
+  const [trending, setTrending] = useState<TrendingSearch[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/trending')
+      .then(res => res.json())
+      .then(data => {
+        setTrending(data.trending || []);
+        setIsLoading(false);
+      })
+      .catch(error => {
+        console.error('Failed to load trending searches:', error);
+        setIsLoading(false);
+      });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="text-center text-gray-400 text-sm">
+        Loading trending searches...
+      </div>
+    );
+  }
+
+  if (trending.length === 0) {
+    return null; // Don't show anything if no data
+  }
+
+  return (
+    <div className="mt-12 text-center">
+      <h2 className="text-sm uppercase tracking-wide text-gray-500 mb-4 font-bold">
+        Most Searched (Last 7 Days)
+      </h2>
+      <div className="flex flex-wrap justify-center gap-2 max-w-2xl mx-auto">
+        {trending.slice(0, 8).map((item) => (
+          <Link
+            key={item.slug}
+            href={`/${item.slug}`}
+            className="px-3 py-1.5 text-sm border border-gray-300 hover:border-black hover:bg-gray-50 transition-colors rounded"
+          >
+            {item.display_name}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/website/app/components/SearchTracker.tsx
+++ b/website/app/components/SearchTracker.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface SearchTrackerProps {
+  slug: string;
+  displayName: string;
+}
+
+export default function SearchTracker({ slug, displayName }: SearchTrackerProps) {
+  useEffect(() => {
+    // Track the search asynchronously (fire and forget)
+    fetch('/api/track-search', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ slug, display_name: displayName }),
+    }).catch((error) => {
+      // Silently fail - don't impact user experience
+      console.debug('Failed to track search:', error);
+    });
+  }, [slug, displayName]);
+
+  return null; // This component doesn't render anything
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import SearchForm from './components/SearchForm';
+import MostSearched from './components/MostSearched';
 
 export default function HomePage() {
   return (
@@ -14,6 +15,9 @@ export default function HomePage() {
           </div>
           <span className="whitespace-nowrap">IN THE EPSTEIN FILES?</span>
         </div>
+
+        {/* Most Searched */}
+        <MostSearched />
 
         {/* Footer */}
         <div className="text-center mt-16 text-xs text-gray-600">

--- a/website/data/searches.json
+++ b/website/data/searches.json
@@ -1,8 +1,0 @@
-{
-  "searches": {
-    "donald-trump": {
-      "count": 8,
-      "lastSearched": 1764013540122
-    }
-  }
-}

--- a/website/lib/supabase.ts
+++ b/website/lib/supabase.ts
@@ -1,0 +1,13 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Server-side Supabase client (uses service role key for admin operations)
+export function getSupabaseClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Missing Supabase environment variables');
+  }
+
+  return createClient(supabaseUrl, supabaseKey);
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "website",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.89.0",
         "@vercel/analytics": "^1.6.0",
         "@vercel/og": "^0.8.5",
         "fuse.js": "^7.1.0",
@@ -5404,6 +5405,86 @@
       "license": "CC0-1.0",
       "peer": true
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.89.0.tgz",
+      "integrity": "sha512-wiWZdz8WMad8LQdJMWYDZ2SJtZP5MwMqzQq3ehtW2ngiI3UTgbKiFrvMUUS3KADiVlk4LiGfODB2mrYx7w2f8w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.89.0.tgz",
+      "integrity": "sha512-XEueaC5gMe5NufNYfBh9kPwJlP5M2f+Ogr8rvhmRDAZNHgY6mI35RCkYDijd92pMcNM7g8pUUJov93UGUnqfyw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.89.0.tgz",
+      "integrity": "sha512-/b0fKrxV9i7RNOEXMno/I1862RsYhuUo+Q6m6z3ar1f4ulTMXnDfv0y4YYxK2POcgrOXQOgKYQx1eArybyNvtg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.89.0.tgz",
+      "integrity": "sha512-aMOvfDb2a52u6PX6jrrjvACHXGV3zsOlWRzZsTIOAJa0hOVvRp01AwC1+nLTGUzxzezejrYeCX+KnnM1xHdl+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.89.0.tgz",
+      "integrity": "sha512-6zKcXofk/M/4Eato7iqpRh+B+vnxeiTumCIP+Tz26xEqIiywzD9JxHq+udRrDuv6hXE+pmetvJd8n5wcf4MFRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.89.0.tgz",
+      "integrity": "sha512-KlaRwSfFA0fD73PYVMHj5/iXFtQGCcX7PSx0FdQwYEEw9b2wqM7GxadY+5YwcmuEhalmjFB/YvqaoNVF+sWUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.89.0",
+        "@supabase/functions-js": "2.89.0",
+        "@supabase/postgrest-js": "2.89.0",
+        "@supabase/realtime-js": "2.89.0",
+        "@supabase/storage-js": "2.89.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -5829,7 +5910,6 @@
       "version": "20.19.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5841,6 +5921,12 @@
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.6",
@@ -5875,6 +5961,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -10999,6 +11094,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -17527,7 +17631,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -18758,7 +18861,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.89.0",
     "@vercel/analytics": "^1.6.0",
     "@vercel/og": "^0.8.5",
     "fuse.js": "^7.1.0",


### PR DESCRIPTION
## Summary
- Adds "Most Searched (Last 7 Days)" section to homepage
- Tracks searches via Supabase when users view result pages
- Graceful degradation - if tracking fails, UX is unaffected

## Changes
- **Database**: `searches` table + `trending_searches` view with RLS
- **API**: `/api/track-search` (POST) and `/api/trending` (GET, 5min cache)
- **Components**: `SearchTracker` (fire-and-forget) + `MostSearched` (homepage UI)
- **Dependencies**: Added `@supabase/supabase-js`

## Prerequisites
- [x] Supabase database created and connected to Vercel
- [x] SQL migration run (`database/001_create_searches_table.sql`)
- [x] Environment variables synced to Vercel

## Test Plan
- [ ] Verify preview deployment loads without errors
- [ ] Search for a name → check Supabase `searches` table has new row
- [ ] Visit homepage → verify "Most Searched" section appears (may be empty initially)
- [ ] Search a few more names → refresh homepage → verify trending updates

## Screenshots
_Will appear after preview deployment_

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)